### PR TITLE
Support sqlite-utils with decimal fix.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     version=VERSION,
     license="Apache License, Version 2.0",
     packages=find_packages(),
-    install_requires=["sqlalchemy", "sqlite-utils~=2.3.1", "click"],
+    install_requires=["sqlalchemy", "sqlite-utils~=2.9.1", "click"],
     extras_require={
         "test": ["pytest"],
         "test_mysql": ["pytest", "mysqlclient"],


### PR DESCRIPTION
In order to upstream the fix in the sqlite-utils repo (https://github.com/simonw/sqlite-utils/issues/110) the version dependency needs to be bumped.