### PR TITLE
Add option to set a PostgreSQL schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For PostgreSQL, use this:
       --pk TEXT                     Optional column to use as a primary key
       --index-fks / --no-index-fks  Should foreign keys have indexes? Default on
       -p, --progress                Show progress bar
+      --postgres-schema TEXT        PostgreSQL schema to use
       --help                        Show this message and exit.
 
 For example, to save the content of the `blog_entry` table from a PostgreSQL database to a local file called `blog.db` you could do this:
@@ -80,6 +81,13 @@ If you want to save the results of a custom SQL query, do this:
         --pk=id
 
 The `--output` option specifies the table that should contain the results of the query.
+
+## Using db-to-sqlite with Postgres schemas
+If the tables you want to copy from your PostgreSQL database aren't in the default schema, you can specify an alternate one with the `--postgres-schema` option:
+
+    db-to-sqlite "postgresql://localhost/myblog" blog.db \
+        --all \
+        --postgres-schema my_schema
 
 ## Using db-to-sqlite with Heroku Postgres
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ If you want to save the results of a custom SQL query, do this:
 
 The `--output` option specifies the table that should contain the results of the query.
 
-## Using db-to-sqlite with Postgres schemas
+## Using db-to-sqlite with PostgreSQL schemas
+
 If the tables you want to copy from your PostgreSQL database aren't in the default schema, you can specify an alternate one with the `--postgres-schema` option:
 
     db-to-sqlite "postgresql://localhost/myblog" blog.db \

--- a/db_to_sqlite/cli.py
+++ b/db_to_sqlite/cli.py
@@ -27,8 +27,9 @@ from sqlite_utils import Database
     help="Should foreign keys have indexes? Default on",
 )
 @click.option("-p", "--progress", help="Show progress bar", is_flag=True)
+@click.option("--postgres-schema", help="PostgreSQL schema to use")
 def cli(
-    connection, path, all, table, skip, redact, sql, output, pk, index_fks, progress
+    connection, path, all, table, skip, redact, sql, output, pk, index_fks, progress, postgres_schema
 ):
     """
     Load data from any database into SQLite.
@@ -53,7 +54,11 @@ def cli(
     for table_name, column_name in redact:
         redact_columns.setdefault(table_name, set()).add(column_name)
     db = Database(path)
-    db_conn = create_engine(connection).connect()
+    if postgres_schema:
+        conn_args = {"options": "-csearch_path={}".format(postgres_schema)}
+    else:
+        conn_args = {}
+    db_conn = create_engine(connection, connect_args=conn_args).connect()
     inspector = inspect(db_conn)
     # Figure out which tables we are copying, if any
     tables = table
@@ -159,3 +164,6 @@ def redacted_dict(row, redact):
         if key in d:
             d[key] = "***"
     return d
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Without this change, you can't use `db-to-sqlite` to copy tables that are in a [Postgres schema](https://www.postgresql.org/docs/13/ddl-schemas.html) other than the default one `public`.