### PR TITLE
Ryancheley patch 1 document updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 dist
 build
+venv

--- a/README.md
+++ b/README.md
@@ -33,15 +33,11 @@ For PostgreSQL, use this:
 
       CONNECTION is a SQLAlchemy connection string, for example:
 
-        PostgreSQL Examples:
+        postgresql://localhost/my_database
+        postgresql://username:passwd@localhost/my_database
 
-          postgresql://localhost/my_database
-          postgresql://username:passwd@localhost/my_database
-
-        MySQL Examples:
-
-          mysql://root@localhost/my_database
-          mysql://username:passwd@localhost/my_database
+        mysql://root@localhost/my_database
+        mysql://username:passwd@localhost/my_database
         
 
       More: https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls

--- a/README.md
+++ b/README.md
@@ -42,26 +42,6 @@ For PostgreSQL, use this:
 
           mysql://root@localhost/my_database
           mysql://username:passwd@localhost/my_database
-
-        MSSQL Examples:
-
-          The best way to get the connection string needed for the MS SQL connections below is to use urllib from the Standard Library as below
-
-          params = urllib.parse.quote_plus(
-                "DRIVER={SQL Server Native Client 11.0};"
-                "SERVER=localhost;"
-                "DATABASE=my_database;"
-                "Trusted_Connection=yes;"
-          )
-
-          The above will resolve to
-
-          DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
-
-          You can then use the string above in the odbc_connect below
-
-          mssql+pyodbc:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
-          mssql+pyodbc:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+UID%3Dusername%3B+PWD%3Dpasswd
         
 
       More: https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls
@@ -114,6 +94,26 @@ If the tables you want to copy from your PostgreSQL database aren't in the defau
     db-to-sqlite "postgresql://localhost/myblog" blog.db \
         --all \
         --postgres-schema my_schema
+
+## Using db-to-sqlite with MS SQL
+
+The best way to get the connection string needed for the MS SQL connections below is to use urllib from the Standard Library as below
+
+    params = urllib.parse.quote_plus(
+        "DRIVER={SQL Server Native Client 11.0};"
+        "SERVER=localhost;"
+        "DATABASE=my_database;"
+        "Trusted_Connection=yes;"
+    )
+
+The above will resolve to
+
+    DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
+
+You can then use the string above in the odbc_connect below
+
+    mssql+pyodbc:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
+    mssql+pyodbc:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+UID%3Dusername%3B+PWD%3Dpasswd
 
 ## Using db-to-sqlite with Heroku Postgres
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,21 @@ For PostgreSQL, use this:
 
       CONNECTION is a SQLAlchemy connection string, for example:
 
+        PostgreSQL Examples:
+
           postgresql://localhost/my_database
           postgresql://username:passwd@localhost/my_database
 
+        MySQL Examples:
+
           mysql://root@localhost/my_database
           mysql://username:passwd@localhost/my_database
+
+        MSSQL Examples:
+
+          mssql+pyodbs:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
+          mssql+pyodbs:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+UID%3Dusername%3B+PWD%3Dpasswd
+        
 
       More: https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ For PostgreSQL, use this:
 
         MSSQL Examples:
 
+          The best way to get the connection string needed for the MS SQL connections below is to use urllib from the Standard Library as below
+
+          params = urllib.parse.quote_plus(
+                "DRIVER={SQL Server Native Client 11.0};"
+                "SERVER=localhost;"
+                "DATABASE="my_database;"
+                "Trusted_Connection=yes;"
+          )
+
+          The above will resolve to
+
+          DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
+
+          You can then use the string above in the odbc_connect below
+
           mssql+pyodbs:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
           mssql+pyodbs:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+UID%3Dusername%3B+PWD%3Dpasswd
         

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For PostgreSQL, use this:
           params = urllib.parse.quote_plus(
                 "DRIVER={SQL Server Native Client 11.0};"
                 "SERVER=localhost;"
-                "DATABASE="my_database;"
+                "DATABASE=my_database;"
                 "Trusted_Connection=yes;"
           )
 
@@ -60,8 +60,8 @@ For PostgreSQL, use this:
 
           You can then use the string above in the odbc_connect below
 
-          mssql+pyodbs:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
-          mssql+pyodbs:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+UID%3Dusername%3B+PWD%3Dpasswd
+          mssql+pyodbc:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+Trusted_Connection%3Dyes
+          mssql+pyodbc:///?odbc_connect=DRIVER%3D%7BSQL+Server+Native+Client+11.0%7D%3B+SERVER%3Dlocalhost%3B+DATABASE%3Dmy_database%3B+UID%3Dusername%3B+PWD%3Dpasswd
         
 
       More: https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You can even do this using a bash one-liner:
 To set up this tool locally, first checkout the code. Then create a new virtual environment:
 
     cd db-to-sqlite
-    python3 -mvenv venv
+    python3 -m venv venv
     source venv/bin/activate
 
 Or if you are using `pipenv`:


### PR DESCRIPTION
@simonw documentation update to include examples for MS SQL

There may be a better way to show it and explain how it should be done, but I'm at a loss. The connection string for MS SQL with SQL Alchemy are just messy. 

I also added headers to the connection string examples to separate them out and make it more clear which example went with which type of SQL. 