### PR TITLE
Added --no_data argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 dist
 build
 venv
+.idea

--- a/db_to_sqlite/cli.py
+++ b/db_to_sqlite/cli.py
@@ -113,12 +113,10 @@ def cli(
                 for column in inspector.get_columns(table):
                     try:
                         column_type = column["type"].python_type
-                        # if column_type == datetime:
-                        #     column_type = column["type"]
                     except NotImplementedError:
                         column_type = str
                     create_columns[column["name"]] = column_type
-                db[table].create(create_columns)
+                db[table].create(create_columns,pks)
             else:
                 if progress:
                     count = db_conn.execute(


### PR DESCRIPTION
The --no_data [table name] argument will copy only the schema, but not any data for the named table. It works similar to the --skip argument in that it can be issued multiple times in a single command line.

Use case for this is transferring an MSSQL database with tables with many rows that you don't need in the sqlite version, but you do need the empty schema. 