### PR TITLE
fix: when there is no data in the table, the primary key is not copied

### DIFF
--- a/db_to_sqlite/cli.py
+++ b/db_to_sqlite/cli.py
@@ -125,7 +125,7 @@ def cli(
                         except NotImplementedError:
                             column_type = str
                         create_columns[column["name"]] = column_type
-                    db[table].create(create_columns)
+                    db[table].create(create_columns, pks)
             else:
                 rows = itertools.chain([first], rows)
                 if progress:

--- a/tests/test_db_to_sqlite.py
+++ b/tests/test_db_to_sqlite.py
@@ -27,7 +27,7 @@ def test_db_to_sqlite(connection, tmpdir, cli_runner):
     assert [{"id": 1, "name": "Lila"}] == list(db["user"].rows)
     assert (
         db["empty_table"].schema
-        == "CREATE TABLE [empty_table] (\n   [id] INTEGER,\n   [name] TEXT,\n   [ip] TEXT\n)"
+        == "CREATE TABLE [empty_table] (\n   [id] INTEGER PRIMARY KEY,\n   [name] TEXT,\n   [ip] TEXT\n)"
     )
     # Check foreign keys
     assert [


### PR DESCRIPTION
When there is no data in the table, the PRIMARY KEY is not copied into the sqlite database.

